### PR TITLE
feat(manager/mise): support assorted mise tools

### DIFF
--- a/lib/modules/manager/mise/extract.spec.ts
+++ b/lib/modules/manager/mise/extract.spec.ts
@@ -48,6 +48,160 @@ describe('modules/manager/mise/extract', () => {
       });
     });
 
+    it('extracts tools - mise registry tools', () => {
+      const content = codeBlock`
+      [tools]
+      actionlint = "1.7.7"
+      aws-cli = "2.25.10"
+      aws-vault = "6.6.1"
+      buf = "1.27.0"
+      consul = "1.14.3"
+      hivemind = "1.1.0"
+      jq = "1.7.1"
+      kafka = "apache-3.9.0"
+      localstack = "4.3.0"
+      opentofu = "1.6.1"
+      protoc = "30.2"
+      shellcheck = "0.10.0"
+      skeema = "1.12.3"
+      sops = "3.10.2"
+      stripe = "1.25.0"
+      terragrunt = "0.72.6"
+      tilt = "0.34.0"
+      tusd = "2.8.0"
+    `;
+      const result = extractPackageFile(content, miseFilename);
+      expect(result).toMatchObject({
+        deps: [
+          {
+            currentValue: '1.7.7',
+            datasource: 'github-releases',
+            depName: 'actionlint',
+            extractVersion: '^v(?<version>\\S+)',
+            packageName: 'rhysd/actionlint',
+          },
+          {
+            currentValue: '2.25.10',
+            datasource: 'github-tags',
+            depName: 'aws-cli',
+            packageName: 'aws/aws-cli',
+          },
+          {
+            currentValue: '6.6.1',
+            datasource: 'github-releases',
+            depName: 'aws-vault',
+            extractVersion: '^v(?<version>\\S+)',
+            packageName: '99designs/aws-vault',
+          },
+          {
+            currentValue: '1.27.0',
+            datasource: 'github-releases',
+            depName: 'buf',
+            extractVersion: '^v(?<version>\\S+)',
+            packageName: 'bufbuild/buf',
+          },
+          {
+            currentValue: '1.14.3',
+            datasource: 'github-releases',
+            depName: 'consul',
+            extractVersion: '^v(?<version>\\S+)',
+            packageName: 'hashicorp/consul',
+          },
+          {
+            currentValue: '1.1.0',
+            datasource: 'github-releases',
+            depName: 'hivemind',
+            extractVersion: '^v(?<version>\\S+)',
+            packageName: 'DarthSim/hivemind',
+          },
+          {
+            currentValue: '1.7.1',
+            datasource: 'github-releases',
+            depName: 'jq',
+            extractVersion: '^jq-v(?<version>\\S+)',
+            packageName: 'jqlang/jq',
+          },
+          {
+            currentValue: '3.9.0',
+            datasource: 'github-tags',
+            depName: 'kafka',
+            extractVersion: '^(?<version>\\S+)',
+            packageName: 'apache/kafka',
+          },
+          {
+            currentValue: '4.3.0',
+            datasource: 'github-releases',
+            depName: 'localstack',
+            extractVersion: '^v(?<version>\\S+)',
+            packageName: 'localstack/localstack',
+          },
+          {
+            currentValue: '1.6.1',
+            datasource: 'github-releases',
+            depName: 'opentofu',
+            extractVersion: '^v(?<version>\\S+)',
+            packageName: 'opentofu/opentofu',
+          },
+          {
+            currentValue: '30.2',
+            datasource: 'github-releases',
+            depName: 'protoc',
+            extractVersion: '^v(?<version>\\S+)',
+            packageName: 'protocolbuffers/protobuf',
+          },
+          {
+            currentValue: '0.10.0',
+            datasource: 'github-releases',
+            depName: 'shellcheck',
+            extractVersion: '^v(?<version>\\S+)',
+            packageName: 'koalaman/shellcheck',
+          },
+          {
+            currentValue: '1.12.3',
+            datasource: 'github-releases',
+            depName: 'skeema',
+            extractVersion: '^v(?<version>\\S+)',
+            packageName: 'skeema/skeema',
+          },
+          {
+            currentValue: '3.10.2',
+            datasource: 'github-releases',
+            depName: 'sops',
+            extractVersion: '^v(?<version>\\S+)',
+            packageName: 'getsops/sops',
+          },
+          {
+            currentValue: '1.25.0',
+            datasource: 'github-releases',
+            depName: 'stripe',
+            extractVersion: '^v(?<version>\\S+)',
+            packageName: 'stripe/stripe-cli',
+          },
+          {
+            currentValue: '0.72.6',
+            datasource: 'github-releases',
+            depName: 'terragrunt',
+            extractVersion: '^v(?<version>\\S+)',
+            packageName: 'gruntwork-io/terragrunt',
+          },
+          {
+            currentValue: '0.34.0',
+            datasource: 'github-releases',
+            depName: 'tilt',
+            extractVersion: '^v(?<version>\\S+)',
+            packageName: 'tilt-dev/tilt',
+          },
+          {
+            currentValue: '2.8.0',
+            datasource: 'github-releases',
+            depName: 'tusd',
+            extractVersion: '^v(?<version>\\S+)',
+            packageName: 'tus/tusd',
+          },
+        ],
+      });
+    });
+
     it('extracts tools - asdf plugins', () => {
       const content = codeBlock`
       [tools]

--- a/lib/modules/manager/mise/upgradeable-tooling.ts
+++ b/lib/modules/manager/mise/upgradeable-tooling.ts
@@ -16,7 +16,7 @@ export interface ToolingDefinition {
 
 export const asdfTooling = upgradeableTooling;
 
-export const miseTooling: Record<string, ToolingDefinition> = {
+const miseCoreTooling: Record<string, ToolingDefinition> = {
   bun: {
     misePluginUrl: 'https://mise.jdx.dev/lang/bun.html',
     config: {
@@ -173,4 +173,163 @@ export const miseTooling: Record<string, ToolingDefinition> = {
       datasource: GithubTagsDatasource.id,
     },
   },
+};
+
+const miseRegistryTooling: Record<string, ToolingDefinition> = {
+  actionlint: {
+    misePluginUrl: 'https://mise.jdx.dev/registry.html#tools',
+    config: {
+      packageName: 'rhysd/actionlint',
+      datasource: GithubReleasesDatasource.id,
+      extractVersion: '^v(?<version>\\S+)',
+    },
+  },
+  'aws-cli': {
+    misePluginUrl: 'https://mise.jdx.dev/registry.html#tools',
+    config: {
+      datasource: GithubTagsDatasource.id,
+      packageName: 'aws/aws-cli',
+    },
+  },
+  'aws-vault': {
+    misePluginUrl: 'https://mise.jdx.dev/registry.html#tools',
+    config: {
+      datasource: GithubReleasesDatasource.id,
+      packageName: '99designs/aws-vault',
+      extractVersion: '^v(?<version>\\S+)',
+    },
+  },
+  buf: {
+    misePluginUrl: 'https://mise.jdx.dev/registry.html#tools',
+    config: {
+      packageName: 'bufbuild/buf',
+      datasource: GithubReleasesDatasource.id,
+      extractVersion: '^v(?<version>\\S+)',
+    },
+  },
+  consul: {
+    misePluginUrl: 'https://mise.jdx.dev/registry.html#tools',
+    config: {
+      packageName: 'hashicorp/consul',
+      datasource: GithubReleasesDatasource.id,
+      extractVersion: '^v(?<version>\\S+)',
+    },
+  },
+  hivemind: {
+    misePluginUrl: 'https://mise.jdx.dev/registry.html#tools',
+    config: {
+      packageName: 'DarthSim/hivemind',
+      datasource: GithubReleasesDatasource.id,
+      extractVersion: '^v(?<version>\\S+)',
+    },
+  },
+  jq: {
+    misePluginUrl: 'https://mise.jdx.dev/registry.html#tools',
+    config: {
+      packageName: 'jqlang/jq',
+      datasource: GithubReleasesDatasource.id,
+      extractVersion: '^jq-v(?<version>\\S+)',
+    },
+  },
+  kafka: {
+    misePluginUrl: 'https://mise.jdx.dev/registry.html#tools',
+    config: (version) => {
+      const apacheMatches = /^apache-(?<version>\d\S+)/.exec(version)?.groups;
+      if (apacheMatches) {
+        return {
+          datasource: GithubTagsDatasource.id,
+          packageName: 'apache/kafka',
+          currentValue: apacheMatches.version,
+          extractVersion: '^(?<version>\\S+)',
+        };
+      }
+
+      return undefined;
+    },
+  },
+  localstack: {
+    misePluginUrl: 'https://mise.jdx.dev/registry.html#tools',
+    config: {
+      packageName: 'localstack/localstack',
+      datasource: GithubReleasesDatasource.id,
+      extractVersion: '^v(?<version>\\S+)',
+    },
+  },
+  opentofu: {
+    misePluginUrl: 'https://mise.jdx.dev/registry.html#tools',
+    config: {
+      packageName: 'opentofu/opentofu',
+      datasource: GithubReleasesDatasource.id,
+      extractVersion: '^v(?<version>\\S+)',
+    },
+  },
+  protoc: {
+    misePluginUrl: 'https://mise.jdx.dev/registry.html#tools',
+    config: {
+      packageName: 'protocolbuffers/protobuf',
+      datasource: GithubReleasesDatasource.id,
+      extractVersion: '^v(?<version>\\S+)',
+    },
+  },
+  shellcheck: {
+    misePluginUrl: 'https://mise.jdx.dev/registry.html#tools',
+    config: {
+      packageName: 'koalaman/shellcheck',
+      datasource: GithubReleasesDatasource.id,
+      extractVersion: '^v(?<version>\\S+)',
+    },
+  },
+  skeema: {
+    misePluginUrl: 'https://mise.jdx.dev/registry.html#tools',
+    config: {
+      packageName: 'skeema/skeema',
+      datasource: GithubReleasesDatasource.id,
+      extractVersion: '^v(?<version>\\S+)',
+    },
+  },
+  sops: {
+    misePluginUrl: 'https://mise.jdx.dev/registry.html#tools',
+    config: {
+      packageName: 'getsops/sops',
+      datasource: GithubReleasesDatasource.id,
+      extractVersion: '^v(?<version>\\S+)',
+    },
+  },
+  stripe: {
+    misePluginUrl: 'https://mise.jdx.dev/registry.html#tools',
+    config: {
+      packageName: 'stripe/stripe-cli',
+      datasource: GithubReleasesDatasource.id,
+      extractVersion: '^v(?<version>\\S+)',
+    },
+  },
+  terragrunt: {
+    misePluginUrl: 'https://mise.jdx.dev/registry.html#tools',
+    config: {
+      packageName: 'gruntwork-io/terragrunt',
+      datasource: GithubReleasesDatasource.id,
+      extractVersion: '^v(?<version>\\S+)',
+    },
+  },
+  tilt: {
+    misePluginUrl: 'https://mise.jdx.dev/registry.html#tools',
+    config: {
+      packageName: 'tilt-dev/tilt',
+      datasource: GithubReleasesDatasource.id,
+      extractVersion: '^v(?<version>\\S+)',
+    },
+  },
+  tusd: {
+    misePluginUrl: 'https://mise.jdx.dev/registry.html#tools',
+    config: {
+      packageName: 'tus/tusd',
+      datasource: GithubReleasesDatasource.id,
+      extractVersion: '^v(?<version>\\S+)',
+    },
+  },
+};
+
+export const miseTooling: Record<string, ToolingDefinition> = {
+  ...miseCoreTooling,
+  ...miseRegistryTooling,
 };


### PR DESCRIPTION
## Changes

Add an assortment of mise tools for renovate to manage.

## Context

With regards to the mise renovate asdf fallback, some of the tools added are also available for asdf. In general, mise and asdf have overlap in their tool registry but is not 1:1. The asdf plugin registry is a fine fallback for mise renovate but I do not think it should preclude us from listing those tools first-class for mise renovate as well.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

```
npm run jest lib/modules/manager/mise/extract.spec.ts
```